### PR TITLE
Fixes syntax error in CanonicalPayload.php

### DIFF
--- a/dispatch-connect/samples/DispatchInbound/PHP/CanonicalPayload.php
+++ b/dispatch-connect/samples/DispatchInbound/PHP/CanonicalPayload.php
@@ -84,7 +84,7 @@ curl_setopt_array($curl, array(
         "Content-Type: application/json",
         "X-Dispatch-Key: $key",
         "X-Dispatch-Signature: $sign",
-        "MessageId": "unique_id_for_transaction"  // optional
+        "MessageId: unique_id_for_transaction"  // optional
     ),
 ));
 $response = curl_exec($curl);


### PR DESCRIPTION
Fixes syntax error in the `CURLOPT_HTTPHEADER` array.